### PR TITLE
Add GeoPackage support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         py_version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.py_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.py_version }}
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 ## Overview
 
-A utility to describe the structure of datasets in netCDF, GeoTiff,
-and ESRI Shapefile format.
+A utility to create profiles of geospatial datasets in a range of formats to assist FAIRification.
+
+For full documentation, please see [the DSprofile documentation](https://ca4eosc.github.io/dsprofile).
 
 ## Installation
 
@@ -25,27 +26,34 @@ $ pytest --cov=dsprofile tests
 ## Usage
 
 ```bash
-usage: dsprofile [-h] {netcdf,geotiff,shape} ...
+usage: dsprofile [-h] [-m] [-d] {netcdf,geotiff,shape,geopackage} ...
 
 Describes datasets in a variety of formats
 
 options:
-  -h, --help           show this help message and exit
+  -h, --help            show this help message and exit
+  -m, --omit-metadata   Output only file contents, not file metadata
+  -d, --omit-digest     Do not include a hash digest in file metadata
 
 Dataset formats:
-  {netcdf,geotiff,shape}
-    netcdf             Extracts metadata from netCDF4 files
-    geotiff            Extracts metadata from GeoTIFF files
-    shape              Extracts metadata from ESRI Shape files
+  {netcdf,geotiff,shape,geopackage}
+    netcdf              Extracts metadata from netCDF4 files
+    geotiff             Extracts metadata from GeoTIFF files
+    shape               Extracts metadata from ESRI Shape files
+    geopackage          Extracts metadata from GeoPackage files
+
+For more information, see ca4eosc.github.io/dsprofile
 ```
 
-## NetCDF Options
+## Reader-specific options
+
+### NetCDF Options
 
 Reads a netCDF4 file and reports the group structure and information
 about any dimensions, variables, and attributes that are defined.
 
 ```bash
-usage: dsprofile netcdf [-h] [-o {category,group}] [-e <group0>,<group1>,...] [-m] [-d] filename
+usage: dsprofile netcdf [-h] [-o {category,group}] [-e <group0>,<group1>,...] filename
 
 positional arguments:
   filename
@@ -56,8 +64,6 @@ options:
                         (default group)
   -e <group0>,<group1>,..., --exclude-groups <group0>,<group1>,...
                         Exclude each of the named <group> arguments
-  -m, --omit-metadata   Output only netCDF file contents, not file metadata
-  -d, --omit-digest     Do not include a hash digest in file metadata
 ```
 
 The `--order-by` option allows the resulting output to be arranged in one of two ways:
@@ -71,7 +77,7 @@ The `--omit-digest` option prevents calculation of a SHA256 hash for the process
 This may be desirable for very large files or test workflows to avoid the potentially
 time-consuming hashing operation.
 
-### NetCDF Example
+#### NetCDF Example
 
 For example, to report on the contents of the netCDF4 file `test.nc` using the default
 output options...
@@ -80,32 +86,28 @@ output options...
 $ dsprofile netcdf test.nc
 ```
 
-## GeoTiff Options
+### GeoTiff Options
 
 ```bash
-usage: dsprofile geotiff [-h] [-m] [-d] filename
+usage: dsprofile geotiff [-h] filename
 
 positional arguments:
   filename
 
 options:
   -h, --help           show this help message and exit
-  -m, --omit-metadata  Output only GeoTIFF file contents, not file metadata
-  -d, --omit-digest    Do not include a hash digest in file metadata
 ```
 
-## ESRI Shapefile Options
+### ESRI Shapefile Options
 
 ```bash
-usage: dsprofile shape [-h] [-m] [-d] filename
+usage: dsprofile shape [-h] filename
 
 positional arguments:
   filename
 
 options:
   -h, --help           show this help message and exit
-  -m, --omit-metadata  Output only Shape file contents, not file metadata
-  -d, --omit-digest    Do not include a hash digest in file metadata
 ```
 
 A Shapefile may be read by opening any of its components, for example...
@@ -120,3 +122,15 @@ $ dsprofile shape shapefile.dbf
 ```
 Note however that where a hex digest of a hash is included in the output,
 this will refer only to file provided as a command-line argument.
+
+### GeoPackage Options
+
+```bash
+usage: dsprofile geopackage [-h] filename
+
+positional arguments:
+  filename
+
+options:
+  -h, --help  show this help message and exit
+```

--- a/dsprofile/lib/__init__.py
+++ b/dsprofile/lib/__init__.py
@@ -4,6 +4,7 @@ from .reader import (  # noqa: F401
     make_reader
 )
 
-from .netcdf import NetCDFReader    # noqa: F401
-from .tiff import GeoTIFFReader     # noqa: F401
-from .shape import ShapefileReader  # noqa: F401
+from .netcdf import NetCDFReader           # noqa: F401
+from .tiff import GeoTIFFReader            # noqa: F401
+from .shape import ShapefileReader         # noqa: F401
+from .geopackage import GeoPackageReader   # noqa: F401

--- a/dsprofile/lib/geopackage.py
+++ b/dsprofile/lib/geopackage.py
@@ -4,6 +4,7 @@ import warnings
 
 import geopandas as gpd
 
+from contextlib import nullcontext
 from io import BytesIO
 
 from dsprofile.lib.reader import Reader
@@ -23,11 +24,21 @@ class GeoPackageReader(Reader):
           Suppress warnings due to "non conformant" filename
           when reading input from a buffer
         """
-        if isinstance(filename, BytesIO):
-            warnings.filterwarnings(module="pyogrio", action="ignore",
-                                    category=RuntimeWarning,
-                                    message=".*non conformant.*")
-        self.layers = gpd.list_layers(filename)
+
+        with warnings.catch_warnings() if isinstance(filename, BytesIO) else nullcontext():
+            #  It's necessary to repeat this check here as
+            #  possible nullcontext results in permanent
+            #  change to global warnings
+            if isinstance(filename, BytesIO):
+                warnings.filterwarnings(module="pyogrio", action="ignore",
+                                        category=RuntimeWarning,
+                                        message=".*non conformant.*")
+            try:
+                self.layers = gpd.list_layers(filename)
+            # RuntimeError captures pyogrio.error's general `DataSourceError`
+            except (OSError, PermissionError, FileNotFoundError, RuntimeError) as e:
+                print(f"{e} for file '{filename}'", file=sys.stderr)
+                sys.exit(1)
 
     @classmethod
     def build_subparser(cls, sp):
@@ -58,7 +69,16 @@ class GeoPackageReader(Reader):
         """
         layers = []
         for idx, layer in self.layers.iterrows():
-            df = gpd.read_file(self.filename, layer=layer["name"])
+            try:
+                with warnings.catch_warnings() if isinstance(self.filename, BytesIO) else nullcontext():
+                    if isinstance(self.filename, BytesIO):
+                        warnings.filterwarnings(module="pyogrio", action="ignore",
+                                                category=RuntimeWarning,
+                                                message=".*non conformant.*")
+                    df = gpd.read_file(self.filename, layer=layer["name"])
+            except (OSError, PermissionError, FileNotFoundError, RuntimeError) as e:
+                print(f"{e} for file '{self.filename}'", file=sys.stderr)
+                sys.exit(1)
             layers.append({
                 "name": layer["name"],
                 "geometry": str(df.active_geometry_name) if hasattr(df, "active_geometry_name") else "None",

--- a/dsprofile/lib/geopackage.py
+++ b/dsprofile/lib/geopackage.py
@@ -41,10 +41,14 @@ class GeoPackageReader(Reader):
         return ctor_args, ctor_kwargs
 
     def read_layers(self):
-        layers = {}
-        for layer in self.layers["name"]:
-            df = gpd.read_file(self.filename, layer=layer)
-            layers[layer] = {col_name: str(df[col_name].dtype) for col_name in df.columns}
+        layers = []
+        for idx, layer in self.layers.iterrows():
+            df = gpd.read_file(self.filename, layer=layer["name"])
+            layers.append({
+                "name": layer["name"],
+                "geometry_type": str(layer["geometry_type"]),
+                "variables": {col_name: str(df[col_name].dtype) for col_name in df.columns}
+            })
 
         return layers
 

--- a/dsprofile/lib/geopackage.py
+++ b/dsprofile/lib/geopackage.py
@@ -1,9 +1,10 @@
 import pathlib
 import sys
+import warnings
 
 import geopandas as gpd
 
-from collections.abc import Sequence
+from io import BytesIO
 
 from dsprofile.lib.reader import Reader
 
@@ -18,6 +19,14 @@ class GeoPackageReader(Reader):
           and no weakref.finalize is required.
         """
         self.filename = filename
+        """
+          Suppress warnings due to "non conformant" filename
+          when reading input from a buffer
+        """
+        if isinstance(filename, BytesIO):
+            warnings.filterwarnings(module="pyogrio", action="ignore",
+                                    category=RuntimeWarning,
+                                    message=".*non conformant.*")
         self.layers = gpd.list_layers(filename)
 
     @classmethod
@@ -41,12 +50,18 @@ class GeoPackageReader(Reader):
         return ctor_args, ctor_kwargs
 
     def read_layers(self):
+        """
+          Describes the variables of each layer defined in the
+          GeoPackage.
+          The "geometry" key records the name of the dataframe column
+          containing geometrical constructs, or "None" if this is absent.
+        """
         layers = []
         for idx, layer in self.layers.iterrows():
             df = gpd.read_file(self.filename, layer=layer["name"])
             layers.append({
                 "name": layer["name"],
-                "geometry_type": str(layer["geometry_type"]),
+                "geometry": str(df.active_geometry_name) if hasattr(df, "active_geometry_name") else "None",
                 "variables": {col_name: str(df[col_name].dtype) for col_name in df.columns}
             })
 
@@ -54,10 +69,3 @@ class GeoPackageReader(Reader):
 
     def process(self):
         return {"layers": self.read_layers()}
-
-
-if __name__ == "__main__":
-    from pprint import pprint
-    gpr = GeoPackageReader("/mnt/xfr/bdnb.gpkg")
-    layers = gpr.process()
-    pprint(layers)

--- a/dsprofile/lib/geopackage.py
+++ b/dsprofile/lib/geopackage.py
@@ -1,0 +1,59 @@
+import pathlib
+import sys
+
+import geopandas as gpd
+
+from collections.abc import Sequence
+
+from dsprofile.lib.reader import Reader
+
+
+class GeoPackageReader(Reader):
+
+    format = "geopackage"
+
+    def __init__(self, filename):
+        """
+          GeoPandas closes input file automatically
+          and no weakref.finalize is required.
+        """
+        self.filename = filename
+        self.layers = gpd.list_layers(filename)
+
+    @classmethod
+    def build_subparser(cls, sp):
+        parser = sp.add_parser(cls.format,
+                               help="Extracts metadata from GeoPackage files")
+        parser.add_argument("filename", type=pathlib.Path)
+
+        return parser
+
+    @classmethod
+    def handle_args(cls, args):
+        if args.filename.is_dir():
+            print(f"A valid file is required not directory '{args.filename}'",
+                  file=sys.stderr)
+            sys.exit(1)
+
+        ctor_args = [args.filename]
+        ctor_kwargs = {}
+
+        return ctor_args, ctor_kwargs
+
+    def read_layers(self):
+        layers = {}
+        for layer in self.layers["name"]:
+            df = gpd.read_file(self.filename, layer=layer)
+            layers[layer] = {col_name: str(df[col_name].dtype) for col_name in df.columns}
+
+        return layers
+
+    def process(self):
+        return {"layers": self.read_layers()}
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+    gpr = GeoPackageReader("/mnt/xfr/bdnb.gpkg")
+    layers = gpr.process()
+    pprint(layers)

--- a/dsprofile/lib/netcdf.py
+++ b/dsprofile/lib/netcdf.py
@@ -184,10 +184,6 @@ class NetCDFReader(Reader):
                             default="group", help="(default group)")
         parser.add_argument("-e", "--exclude-groups", metavar="<group0>,<group1>,...",
                             help="Exclude each of the named <group> arguments")
-        parser.add_argument("-m", "--omit-metadata", action="store_true",
-                            help="Output only netCDF file contents, not file metadata")
-        parser.add_argument("-d", "--omit-digest", action="store_true",
-                            help="Do not include a hash digest in file metadata")
         return parser
 
     @classmethod

--- a/dsprofile/lib/shape.py
+++ b/dsprofile/lib/shape.py
@@ -37,10 +37,7 @@ class ShapefileReader(Reader):
         parser = sp.add_parser(cls.format,
                                help="Extracts metadata from ESRI Shape files")
         parser.add_argument("filename", type=pathlib.Path)
-        parser.add_argument("-m", "--omit-metadata", action="store_true",
-                            help="Output only Shape file contents, not file metadata")
-        parser.add_argument("-d", "--omit-digest", action="store_true",
-                            help="Do not include a hash digest in file metadata")
+
         return parser
 
     @classmethod

--- a/dsprofile/lib/tiff.py
+++ b/dsprofile/lib/tiff.py
@@ -42,10 +42,7 @@ class GeoTIFFReader(Reader):
         parser = sp.add_parser(cls.format,
                                help="Extracts metadata from GeoTIFF files")
         parser.add_argument("filename", type=pathlib.Path)
-        parser.add_argument("-m", "--omit-metadata", action="store_true",
-                            help="Output only GeoTIFF file contents, not file metadata")
-        parser.add_argument("-d", "--omit-digest", action="store_true",
-                            help="Do not include a hash digest in file metadata")
+
         return parser
 
     @classmethod

--- a/dsprofile/main.py
+++ b/dsprofile/main.py
@@ -21,8 +21,13 @@ def parse_args(argv):
     parser = argparse.ArgumentParser(
         prog="dsprofile",
         description="Describes datasets in a variety of formats",
-        epilog="For more information, see github.com/eScienceLab/dsprofile"
+        epilog="For more information, see ca4eosc.github.io/dsprofile"
     )
+
+    parser.add_argument("-m", "--omit-metadata", action="store_true",
+                        help="Output only file contents, not file metadata")
+    parser.add_argument("-d", "--omit-digest", action="store_true",
+                        help="Do not include a hash digest in file metadata")
 
     sp = parser.add_subparsers(title="Dataset formats",
                                dest="command")

--- a/dsprofile/util.py
+++ b/dsprofile/util.py
@@ -40,8 +40,13 @@ def make_file_profile(ctx) -> dict:
     if not ctx.omit_digest:
         from hashlib import sha256
         h = sha256()
-        with open(ctx.filename, 'rb') as fp:
-            h.update(fp.read())
+        try:
+            with open(ctx.filename, 'rb') as fp:
+                h.update(fp.read())
+        except (PermissionError, FileNotFoundError, OSError) as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
         origin["file"]["digest"] = h.hexdigest()
 
     return origin

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         "netCDF4",
         "earthpy",             # Includes GeoPandas, rasterio
         "fiona",               # ESRI Shapefile support
-        "pyproj"               # CRS parsing
+        "pyproj",              # CRS parsing
+        "shapely"              # Geometry constructs
     ],
     extras_require = {
         "dev": dev_requires,

--- a/tests/test_geopackage.py
+++ b/tests/test_geopackage.py
@@ -1,34 +1,162 @@
-import os
+import math
+import random
+import subprocess
+import tempfile
 
+from io import BytesIO
+from shapely import Point
+
+import geopandas as gpd
 import pytest
 
 from dsprofile.lib.geopackage import GeoPackageReader
 
 
-TEST_DATA_PATH = os.getenv("DSPROFILE_TEST_DATA_PATH")
+def make_names(count):
+    """
+      Generate a sequence of names in ascending
+      'powers' of A-Z: A,...,Z,AA,...,AZ,AAA,...
+    """
+    def exp26(i):
+        seq = []
+        i += 1
+        while i != 0:
+            i -= 1
+            seq.insert(0, i%26)
+            i //= 26
+
+        if len(seq) == 0:
+            seq = [0]
+        return seq
+
+    return ["".join(chr(65 + d) for d in exp26(i)) for i in range(abs(count))]
 
 
 @pytest.fixture
-def synthetic_test_file(request):
-    if TEST_DATA_PATH:
-        test_dir = TEST_DATA_PATH
-    else:
-        base_dir = os.path.dirname(request.module.__file__)
-        test_dir = os.path.join(base_dir, "data")
-    return {
-        "path": os.path.join(test_dir, "test.gpkg")
-        # TODO
-    }
+def geometry_geodataframe():
+    """
+      Generate a GeoPandas GeoDataFrame with geometry col containing
+      a sequence of Points having random (lat, long) coords
+    """
+    base_lat, base_long = 53.5, -2.25
+    lat_band = random.uniform(25.0, 35.0)
+
+    pcount = random.randint(160, 320)
+    crs = "EPSG:4326"
+
+    lat_longs = [(round(base_lat + math.sin(i*math.pi/(pcount/2))*lat_band, 2),
+                  round(base_long + i*180/pcount, 2)) for i in range(pcount)]
+
+    return gpd.GeoDataFrame({"names": make_names(pcount)}, geometry=[Point(c) for c in lat_longs], crs=crs)
+
+
+@pytest.fixture
+def elevation_geodataframe():
+    """
+      Generate a GeoPandas GeoDataFrame containing a sequence
+      of random elevations
+    """
+    base_elev = 100
+    elev_band = random.uniform(80, 120)
+
+    pcount = random.randint(160, 320)
+
+    elevations = [round(base_elev + math.sin(i*math.pi/(pcount/2))*elev_band, 2) for i in range(pcount)]
+
+    return gpd.GeoDataFrame({"names": make_names(pcount), "Elevation": elevations})
+
+
+@pytest.fixture
+def multi_layer_tempfile(geometry_geodataframe, elevation_geodataframe, scope="module"):
+    """
+      Create a temporary file containing the geometry and elevation
+      GeoDataframes as layers.
+      Note that the `pyogrio` library underlying GeoPandas does not support
+      writing multiple layers to a BytesIO buffer (as in `single_layer_buf`
+      below) so a temp file is required here.
+    """
+    buf = tempfile.NamedTemporaryFile(suffix=".gpkg")
+
+    geometry_geodataframe.to_file(buf.name, layer="Points", driver="GPKG")
+    elevation_geodataframe.to_file(buf.name, layer="Elevation", driver="GPKG")
+
+    yield buf
+
+
+@pytest.fixture
+def single_layer_buf(geometry_geodataframe, scope="module"):
+    """
+      Create a byte buffer containing a GeoDataFrame
+    """
+    buf = BytesIO()
+    # Note it's necessary to specify a layer name for
+    # even a single layer or a driver-specific arbitrary
+    # layer name is used
+    geometry_geodataframe.to_file(buf, layer="Points", driver="GPKG")
+    yield buf
+
+
+var_name_map = {
+    "Points": (("geometry", "geometry"), ("names", "str")),
+    "Elevation": (("Elevation", "float64"), ("names", "str"))
+}
 
 
 class TestGeoPackage:
-    def test_reader_instance(self, synthetic_test_file):
+    def test_reader_instance(self, multi_layer_tempfile):
         """
           Can an instance of the GeoPackageReader be
           created and does it have the correct defaults?
         """
+        inst = GeoPackageReader(multi_layer_tempfile.name)
+        assert len(inst.layers) == 2
 
-    def test_read_dataset(self, synthetic_test_file):
+    def test_read_dataset_file(self, multi_layer_tempfile):
         """
-          Can a GeoPackage file be opened correctly?
+          Does the output from reading a GeoPackage file
+          have the expected form, values, and types?
         """
+        inst = GeoPackageReader(multi_layer_tempfile.name)
+        out = inst.process()
+        for layer in out["layers"]:
+            for name, dtype in var_name_map[layer["name"]]:
+                assert name in layer["variables"]
+                assert layer["variables"][name] == dtype
+
+    def test_read_dataset_buf(self, single_layer_buf):
+        """
+          Does the output from reading a GeoPackage buffer
+          have the expected form, values, and types?
+        """
+        inst = GeoPackageReader(single_layer_buf)
+        assert len(inst.layers) == 1
+        out = inst.process()
+        for layer in out["layers"]:    # There's only one
+            for name, dtype in var_name_map[layer["name"]]:
+                assert name in layer["variables"]
+                assert layer["variables"][name] == dtype
+
+    def test_cli(self):
+        """
+          Can the command-line script be invoked using the
+          GeoPackageReader's `format` attribute?
+        """
+        args = ["dsprofile", GeoPackageReader.format, "-h"]
+        proc = subprocess.Popen(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        sout, serr = proc.communicate()
+        assert sout.startswith(b"usage")
+        assert len(serr) == 0    # Should be an empty bytes: b""
+        assert proc.returncode == 0
+
+    def test_geometry(self, multi_layer_tempfile):
+        """
+          Does the Reader correctly identify the presence or absence
+          of a geometry column?
+        """
+        inst = GeoPackageReader(multi_layer_tempfile.name)
+        geom_out = inst.process()
+        for layer in geom_out["layers"]:
+            if layer["name"] == "Points":
+                assert layer["geometry"] == "geometry"
+            elif layer["name"] == "Elevation":
+                assert layer["geometry"] == "None"

--- a/tests/test_geopackage.py
+++ b/tests/test_geopackage.py
@@ -1,0 +1,34 @@
+import os
+
+import pytest
+
+from dsprofile.lib.geopackage import GeoPackageReader
+
+
+TEST_DATA_PATH = os.getenv("DSPROFILE_TEST_DATA_PATH")
+
+
+@pytest.fixture
+def synthetic_test_file(request):
+    if TEST_DATA_PATH:
+        test_dir = TEST_DATA_PATH
+    else:
+        base_dir = os.path.dirname(request.module.__file__)
+        test_dir = os.path.join(base_dir, "data")
+    return {
+        "path": os.path.join(test_dir, "test.gpkg")
+        # TODO
+    }
+
+
+class TestGeoPackage:
+    def test_reader_instance(self, synthetic_test_file):
+        """
+          Can an instance of the GeoPackageReader be
+          created and does it have the correct defaults?
+        """
+
+    def test_read_dataset(self, synthetic_test_file):
+        """
+          Can a GeoPackage file be opened correctly?
+        """

--- a/tests/test_geopackage.py
+++ b/tests/test_geopackage.py
@@ -32,7 +32,7 @@ def make_names(count):
     return ["".join(chr(65 + d) for d in exp26(i)) for i in range(abs(count))]
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def geometry_geodataframe():
     """
       Generate a GeoPandas GeoDataFrame with geometry col containing
@@ -50,7 +50,7 @@ def geometry_geodataframe():
     return gpd.GeoDataFrame({"names": make_names(pcount)}, geometry=[Point(c) for c in lat_longs], crs=crs)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def elevation_geodataframe():
     """
       Generate a GeoPandas GeoDataFrame containing a sequence
@@ -66,8 +66,8 @@ def elevation_geodataframe():
     return gpd.GeoDataFrame({"names": make_names(pcount), "Elevation": elevations})
 
 
-@pytest.fixture
-def multi_layer_tempfile(geometry_geodataframe, elevation_geodataframe, scope="module"):
+@pytest.fixture(scope="module")
+def multi_layer_tempfile(geometry_geodataframe, elevation_geodataframe):
     """
       Create a temporary file containing the geometry and elevation
       GeoDataframes as layers.
@@ -75,16 +75,17 @@ def multi_layer_tempfile(geometry_geodataframe, elevation_geodataframe, scope="m
       writing multiple layers to a BytesIO buffer (as in `single_layer_buf`
       below) so a temp file is required here.
     """
-    buf = tempfile.NamedTemporaryFile(suffix=".gpkg")
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".gpkg")
 
-    geometry_geodataframe.to_file(buf.name, layer="Points", driver="GPKG")
-    elevation_geodataframe.to_file(buf.name, layer="Elevation", driver="GPKG")
+    geometry_geodataframe.to_file(tmpfile.name, layer="Points", driver="GPKG")
+    elevation_geodataframe.to_file(tmpfile.name, layer="Elevation", driver="GPKG")
 
-    yield buf
+    yield tmpfile
+    tmpfile.close()
 
 
-@pytest.fixture
-def single_layer_buf(geometry_geodataframe, scope="module"):
+@pytest.fixture(scope="module")
+def single_layer_buf(geometry_geodataframe):
     """
       Create a byte buffer containing a GeoDataFrame
     """
@@ -93,7 +94,9 @@ def single_layer_buf(geometry_geodataframe, scope="module"):
     # even a single layer or a driver-specific arbitrary
     # layer name is used
     geometry_geodataframe.to_file(buf, layer="Points", driver="GPKG")
+    buf.seek(0)
     yield buf
+    buf.close()
 
 
 var_name_map = {

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import pytest
 
@@ -53,7 +54,7 @@ class TestNetCDF:
           in the expected order?
         """
         r = NetCDFReader(synthetic_test_file["path"])
-        r.process()
+        _ = r.process()
         groupnames = [group.path for groups in r.walk_groups(r.ds) for group in groups]
         for idx in range(len(groupnames)):
             assert groupnames[idx] == synthetic_test_file["groups"][idx]
@@ -69,3 +70,30 @@ class TestNetCDF:
         filtered_groups = [group for group in synthetic_test_file["groups"] if not group.startswith(exclusion)]
         for idx in range(len(groupnames)):
             assert groupnames[idx] == filtered_groups[idx]
+
+    def test_order_by(self, synthetic_test_file):
+        """
+          Do the orderings by `group` and by `category` produce
+          the expected output?
+        """
+        r_cat = NetCDFReader(synthetic_test_file["path"], order_by="category")
+        out = r_cat.process()
+        for category in ("dimensions", "variables", "attributes"):
+            assert category in out
+        
+        r_grp = NetCDFReader(synthetic_test_file["path"], order_by="group")
+        out = r_grp.process()
+        for group in synthetic_test_file["groups"]:
+            assert group in out
+
+    def test_cli(self):
+        """
+          Can the command-line script be invoked using the
+          NetCDFReader's `format` attribute?
+        """
+        args = ["dsprofile", NetCDFReader.format, "-h"]
+        proc = subprocess.Popen(args, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        sout, serr = proc.communicate()
+        assert sout.startswith(b"usage")
+        assert len(serr) == 0    # Should be an empty bytes: b""
+        assert proc.returncode == 0

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,7 +4,8 @@ from packaging import version
 min_version_map = {
     "netCDF4": version.parse("1.7.0"),
     "rasterio": version.parse("1.4.0"),
-    "fiona": version.parse("0.9.0")
+    "fiona": version.parse("0.9.0"),
+    "geopandas": version.parse("1.1.0")
 }
 
 


### PR DESCRIPTION
This add the `GeoPackage` component of #5 along with tests and documentation.

Some additional changes:

* Bump the versions of workflow actions in order to avoid Node deprecation warnings
* Reorganise command-line arguments
* Improve test coverage in the `NetCDFReader`

Tests are set to fail if coverage (currently 60%) falls below 50%.